### PR TITLE
Added logic to handle "ignoring" all day events.

### DIFF
--- a/config/bot.php.example
+++ b/config/bot.php.example
@@ -6,11 +6,9 @@
   date_default_timezone_set('America/Chicago');
   $today = date('Y-m-d');
   /**
-   * Respect all-day events. Don't generate a tweet until all-day events are complete (assumes midnight).
-   *  - 'false' = tweets/progress will begin immediately after event's start date/time.
-   *  - 'true' (bot default) = tweets will generate begining at midnight following event's start date.
-   * Option 'false' will cause a first "day of" tweet like `0% of the way from Event to Same Event!` and is more
-   *  or less unused (future improvement request). Would not recommend using 'false' in production.
+   * Respect all-day events. Don't generate a tweet until all-day events are complete (assumes 23:59:59/midnight).
+   *  - 'false' = tweets/progress will begin immediately after event's first announcement/start date/time.
+   *  - 'true' (bot default) = tweets will generate begining at midnight _after_ event's start date.
    */
   $respectAllDayEvents = true;
   /**


### PR DESCRIPTION
Added the requisite logic to handle `$respectAllDayEvents = false` in an appropriate way so tweets can/will be posted following the announcement of the current day's all-day event.

Also created simple function to get a given Event's date.

The behavior of `$respectAllDayEvents = true` (bot default) is unaffected -- when this is set the bot will skip tweeting until ~midnight following the event. Additionally clarified the `bot.php.example` description text appropriately.